### PR TITLE
Docker support added(#1)

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,41 @@
+# Dependencies
+node_modules
+npm-debug.log
+yarn-debug.log
+yarn-error.log
+
+# Testing
+coverage
+.nyc_output
+
+# Production build
+build
+
+# Version control
+.git
+.gitignore
+
+# IDE
+.vscode
+.idea
+
+# Environment
+.env
+.env.local
+.env.development.local
+.env.test.local
+.env.production.local
+
+# OS generated
+.DS_Store
+.DS_Store?
+._*
+.Spotlight-V100
+.Trashes
+ehthumbs.db
+Thumbs.db
+
+# Project specific
+screenshots
+README.md
+LICENSE.md

--- a/dockerfile
+++ b/dockerfile
@@ -1,0 +1,16 @@
+FROM node:18-alpine
+
+WORKDIR /app
+
+COPY package.json yarn.lock ./
+RUN yarn install --production --frozen-lockfile
+
+COPY . .
+
+RUN yarn build
+
+EXPOSE 3000
+
+
+RUN yarn global add serve
+ENTRYPOINT ["serve", "-s", "build", "-l", "3000"]


### PR DESCRIPTION
Closes #1

This PR adds Docker support to the project for consistent local development and testing environments.

### Changes Made
- Added Dockerfile for containerization
- Added .dockerignore file to optimize build process
- Configured production-ready Node.js Alpine image
- Set up serve package to handle static file serving

### Docker Setup Details
- Base image: node:18-alpine
- Production dependencies only
- Serves built static files on port 3000
- Optimized for small image size

### Local Testing Steps
```bash
# Build image
docker build -t iptv .

# Run container
docker run -d --name testiptv -p 3000:3000 iptv